### PR TITLE
fix(train): don't save model when tuning for auto batch size

### DIFF
--- a/src/so_vits_svc_fork/train.py
+++ b/src/so_vits_svc_fork/train.py
@@ -254,7 +254,8 @@ class VitsLightning(pl.LightningModule):
             torch.stft = stft
 
     def on_train_end(self) -> None:
-        self.save_checkpoints(adjust=0)
+        if not self.tuning:
+            self.save_checkpoints(adjust=0)
 
     def save_checkpoints(self, adjust=1):
         # `on_train_end` will be the actual epoch, not a -1, so we have to call it with `adjust = 0`
@@ -546,5 +547,5 @@ class VitsLightning(pl.LightningModule):
             )
 
     def on_validation_end(self) -> None:
-        if not self.trainer.sanity_checking:
+        if not self.trainer.sanity_checking and not self.tuning:
             self.save_checkpoints()


### PR DESCRIPTION
With the addition of the `on_train_end` hook in 3.10.2 the checkpoints are now being saved when running auto batch size finding.

This PR adds a check for `self.tuning` and will not be saving checkpoints if it's true.