### PR TITLE
chore(easy-installation): replace exit with pause

### DIFF
--- a/easy-installation/install.bat
+++ b/easy-installation/install.bat
@@ -31,14 +31,20 @@ if %errorlevel%==0 (
     if %errorlevel%==0 (
         echo CUDA is already installed.
     ) else (
-        echo Please install CUDA 11.7 from https://developer.nvidia.com/cuda-11-8-0-download-archive?target_os=Windows & exit /b 1
+        echo CUDA is not installed.
+        echo Please install CUDA 11.7 from https://developer.nvidia.com/cuda-11-8-0-download-archive?target_os=Windows
+        echo If you are sure it is already installed and added to path, press any key to force the installation to continue
+        Pause
     )
 
     echo Checking cuDNN...
     if exist "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8\bin\cudnn64_8.dll" (
         echo cuDNN is already installed.
     ) else (
-        echo Please install cuDNN for CUDA 11.x from https://developer.nvidia.com/cudnn (https://developer.nvidia.com/downloads/compute/cudnn/secure/8.8.1/local_installers/11.8/cudnn-windows-x86_64-8.8.1.3_cuda11-archive.zip/) & exit /b 1
+        echo cuDNN is not installed.
+        echo Please install cuDNN 11.8 from https://developer.nvidia.com/cudnn (https://developer.nvidia.com/downloads/compute/cudnn/secure/8.8.1/local_installers/11.8/cudnn-windows-x86_64-8.8.1.3_cuda11-archive.zip/)
+        echo If you are sure it is already installed and added to path, press any key to force the installation to continue
+        Pause
     )
 )
 


### PR DESCRIPTION
So when we run the [install.bat],if the CUDA or CUDNN haven't installed, the bat will just disappeared and will not show anything, it is very confusing.like https://github.com/34j/so-vits-svc-fork/issues/374

To see the error messages, We need to run .bat from a console windows,This is very unfriendly to the beginner.So I replaced "exit" with "pause”.

Also, the “pause” gives user an option to force continue the installation process if the installer can’t correctly identified the CUDA or CUDNN which is install correctly.