### PR TITLE
fix(utils): fix epoch variable name in checkpoint save/load functions

### DIFF
--- a/src/so_vits_svc_fork/utils.py
+++ b/src/so_vits_svc_fork/utils.py
@@ -256,7 +256,7 @@ def load_checkpoint(
             warnings.simplefilter("ignore")
             safe_load(optimizer, checkpoint_dict["optimizer"])
 
-    LOG.info(f"Loaded checkpoint '{checkpoint_path}' (iteration {iteration})")
+    LOG.info(f"Loaded checkpoint '{checkpoint_path}' (epoch {iteration})")
     return model, optimizer, learning_rate, iteration
 
 
@@ -268,7 +268,7 @@ def save_checkpoint(
     checkpoint_path: Path | str,
 ) -> None:
     LOG.info(
-        "Saving model and optimizer state at iteration {} to {}".format(
+        "Saving model and optimizer state at epoch {} to {}".format(
             iteration, checkpoint_path
         )
     )


### PR DESCRIPTION
It seems there was a typo/mistake in the checkpoint save/load functions, and the variable was called `iteration` instead of `epoch`, and the same typo is present in the save/load log messages, which was confusing to users.

As you can see in code below, we're actually passing `current_epoch` into save function.
https://github.com/voicepaw/so-vits-svc-fork/blob/ed3240a15e8c2584f2ec7e47df89f70ef6ee2920/src/so_vits_svc_fork/train.py#L275-L290

I fixed that typo, but left it as an `iteration` in the actual torch data structure to maintain backward compatibility with existing checkpoint files for this model.

