### PR TITLE
fix(train): decouple lf0 predictor from speaker embeddings

### DIFF
--- a/src/so_vits_svc_fork/modules/decoders/f0.py
+++ b/src/so_vits_svc_fork/modules/decoders/f0.py
@@ -37,6 +37,7 @@ class F0Decoder(nn.Module):
     def forward(self, x, norm_f0, x_mask, spk_emb=None):
         x = torch.detach(x)
         if spk_emb is not None:
+            spk_emb = torch.detach(spk_emb)
             x = x + self.cond(spk_emb)
         x += self.f0_prenet(norm_f0)
         x = self.prenet(x) * x_mask


### PR DESCRIPTION
Prevents the f0 decoder from modifying the speaker embeddings when lf0 loss is minimized.  Not sure how much this matters - I would appreciate feedback if anyone notices a difference in training.