### PR TITLE
fix: pass string path to librosa and soundfile

### DIFF
--- a/src/so_vits_svc_fork/inference/main.py
+++ b/src/so_vits_svc_fork/inference/main.py
@@ -53,7 +53,7 @@ def infer(
         device=device,
     )
 
-    audio, _ = librosa.load(input_path, sr=svc_model.target_sample)
+    audio, _ = librosa.load(str(input_path), sr=svc_model.target_sample)
     audio = svc_model.infer_silence(
         audio.astype(np.float32),
         speaker=speaker,
@@ -69,7 +69,7 @@ def infer(
         max_chunk_seconds=max_chunk_seconds,
     )
 
-    soundfile.write(output_path, audio, svc_model.target_sample)
+    soundfile.write(str(output_path), audio, svc_model.target_sample)
 
 
 def realtime(


### PR DESCRIPTION
### Summary

Changed path arguments passed to `librosa` and `soundfile` functions used in inference to avoid path errors in some environments like temp files in docker containers.