### PR TITLE
feat: update pretrained model url, raise error if there are no files to preprocess, shuffle files consistently

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
   <img src="https://img.shields.io/pypi/l/so-vits-svc-fork.svg?style=flat-square" alt="License">
 </p>
 
-A fork of [`so-vits-svc`](https://github.com/svc-develop-team/so-vits-svc) with **realtime support** and **greatly improved interface**. Based on branch `4.0` (v1) and the models are compatible.
+A fork of [`so-vits-svc`](https://github.com/svc-develop-team/so-vits-svc) with **realtime support** and **greatly improved interface**. Based on branch `4.0` (v1) (or `4.1`) and the models are compatible.
 
 ## Features not available in the original repo
 

--- a/src/so_vits_svc_fork/__main__.py
+++ b/src/so_vits_svc_fork/__main__.py
@@ -546,7 +546,7 @@ from so_vits_svc_fork.preprocessing.preprocess_flist_config import CONFIG_TEMPLA
     "-t",
     "--config-type",
     type=click.Choice([x.stem for x in CONFIG_TEMPLATE_DIR.rglob("*.json")]),
-    default="so-vits-svc-4.0v1-legacy",
+    default="so-vits-svc-4.0v1",
     help="config type",
 )
 def pre_config(

--- a/src/so_vits_svc_fork/preprocessing/config_templates/quickvc.json
+++ b/src/so_vits_svc_fork/preprocessing/config_templates/quickvc.json
@@ -68,7 +68,11 @@
     "type_": "ms-istft",
     "gen_istft_n_fft": 16,
     "gen_istft_hop_size": 4,
-    "subbands": 4
+    "subbands": 4,
+    "pretrained": {
+      "D_0.pth": "https://huggingface.co/datasets/ms903/sovits4.0-768vec-layer12/resolve/main/sovits_768l12_pre_large_320k/clean_D_320000.pth",
+      "G_0.pth": "https://huggingface.co/datasets/ms903/sovits4.0-768vec-layer12/resolve/main/sovits_768l12_pre_large_320k/clean_G_320000.pth"
+    }
   },
   "spk": {}
 }

--- a/src/so_vits_svc_fork/preprocessing/config_templates/so-vits-svc-4.0v1-legacy.json
+++ b/src/so_vits_svc_fork/preprocessing/config_templates/so-vits-svc-4.0v1-legacy.json
@@ -59,7 +59,11 @@
     "use_spectral_norm": false,
     "gin_channels": 256,
     "ssl_dim": 256,
-    "n_speakers": 200
+    "n_speakers": 200,
+    "pretrained": {
+      "D_0.pth": "https://huggingface.co/therealvul/so-vits-svc-4.0-init/resolve/main/D_0.pth",
+      "G_0.pth": "https://huggingface.co/therealvul/so-vits-svc-4.0-init/resolve/main/G_0.pth"
+    }
   },
   "spk": {}
 }

--- a/src/so_vits_svc_fork/preprocessing/config_templates/so-vits-svc-4.0v1.json
+++ b/src/so_vits_svc_fork/preprocessing/config_templates/so-vits-svc-4.0v1.json
@@ -61,7 +61,11 @@
     "gin_channels": 256,
     "ssl_dim": 768,
     "n_speakers": 200,
-    "type_": "hifi-gan"
+    "type_": "hifi-gan",
+    "pretrained": {
+      "D_0.pth": "https://huggingface.co/datasets/ms903/sovits4.0-768vec-layer12/resolve/main/sovits_768l12_pre_large_320k/clean_D_320000.pth",
+      "G_0.pth": "https://huggingface.co/datasets/ms903/sovits4.0-768vec-layer12/resolve/main/sovits_768l12_pre_large_320k/clean_G_320000.pth"
+    }
   },
   "spk": {}
 }

--- a/src/so_vits_svc_fork/preprocessing/preprocess_flist_config.py
+++ b/src/so_vits_svc_fork/preprocessing/preprocess_flist_config.py
@@ -5,8 +5,8 @@ import os
 from copy import deepcopy
 from logging import getLogger
 from pathlib import Path
-from random import shuffle
 
+import numpy as np
 from librosa import get_duration
 from tqdm import tqdm
 
@@ -32,6 +32,7 @@ def preprocess_config(
     test = []
     spk_dict = {}
     spk_id = 0
+    random = np.random.RandomState(1234)
     for speaker in os.listdir(input_dir):
         spk_dict[speaker] = spk_id
         spk_id += 1
@@ -41,7 +42,7 @@ def preprocess_config(
                 LOG.warning(f"skip {path} because it is too short.")
                 continue
             paths.append(path)
-        shuffle(paths)
+        random.shuffle(paths)
         if len(paths) <= 4:
             raise ValueError(
                 f"too few files in {input_dir / speaker} (expected at least 5)."

--- a/src/so_vits_svc_fork/preprocessing/preprocess_resample.py
+++ b/src/so_vits_svc_fork/preprocessing/preprocess_resample.py
@@ -103,9 +103,11 @@ def preprocess_resample(
     output_dir = Path(output_dir)
     """Preprocess audio files in input_dir and save them to output_dir."""
 
-    in_paths = []
     out_paths = []
-    for in_path in input_dir.rglob("*.*"):
+    in_paths = list(input_dir.rglob("*.*"))
+    if not in_paths:
+        raise ValueError(f"No audio files found in {input_dir}")
+    for in_path in in_paths:
         in_path_relative = in_path.relative_to(input_dir)
         if not in_path.is_absolute() and is_relative_to(
             in_path, Path("dataset_raw") / "44k"
@@ -125,7 +127,6 @@ def preprocess_resample(
         out_path = output_dir / speaker_name / file_name
         out_path = _get_unique_filename(out_path, out_paths)
         out_path.parent.mkdir(parents=True, exist_ok=True)
-        in_paths.append(in_path)
         out_paths.append(out_path)
 
     in_and_out_paths = list(zip(in_paths, out_paths))


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

<!--
  First, have Copilot write it down.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2f15ae2</samp>

### Summary
📝🛠️🚀

<!--
1.  📝 - This emoji represents the change that updates the README.md file, as it is a documentation change that informs the users about the latest branch name.
2.  🛠️ - This emoji represents the change that updates the default config type for the command line interface, as it is a bug fix that resolves the issue of using a legacy config that is no longer compatible with the current codebase.
3.  🚀 - This emoji represents the change that adds the pretrained model URLs for the different configs to the JSON file, as it is a feature enhancement that enables the users to download the models easily and quickly.
-->
This pull request introduces several improvements and updates to the `so-vits-svc-fork` module, such as adding numpy as a dependency, using a fixed random seed, enhancing the error handling and code clarity of the preprocessing functions, updating the training and model loading methods, and adding the pretrained model URLs to the config templates. It also updates the README.md file and the default config type for the command line interface.

> _The `so-vits-svc-fork` repo_
> _Has some changes that you should know_
> _It has new configs and models_
> _And some code that coddles_
> _The users who want to train with `quickvc`_

### Walkthrough
*  Update README.md to use the latest branch name `4.1` ([link](https://github.com/voicepaw/so-vits-svc-fork/pull/715/files?diff=unified&w=0#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L35-R35))
*  Change default config type for command line interface to `so-vits-svc-4.0v1` ([link](https://github.com/voicepaw/so-vits-svc-fork/pull/715/files?diff=unified&w=0#diff-1e96e26cdf5a3809068061c9616dc62d3158dc61dc3e8321ce9310d019430285L549-R549))
*  Add pretrained model URLs for `quickvc`, `so-vits-svc-4.0v1-legacy`, and `so-vits-svc-4.0v1` configs to JSON files ([link](https://github.com/voicepaw/so-vits-svc-fork/pull/715/files?diff=unified&w=0#diff-20ed4162c09cc26411e842dbff475e6c5cea15905b2bf9fa17191440bf805238L71-R75), [link](https://github.com/voicepaw/so-vits-svc-fork/pull/715/files?diff=unified&w=0#diff-1a284fac8e882b112db442c7545c0ca7d3d426497d1fb99f97b99704e648afcbL62-R66), [link](https://github.com/voicepaw/so-vits-svc-fork/pull/715/files?diff=unified&w=0#diff-499a8dc5fba763139f1868efd0a0dd2e14a962673ea90a471e40ed2a6920b261L64-R68))
*  Modify `ensure_pretrained_model` function to accept model type or URLs dictionary and download models in parallel ([link](https://github.com/voicepaw/so-vits-svc-fork/pull/715/files?diff=unified&w=0#diff-8036cfa6b74c166b17d0a5165f2077acbae837bc9b3ceafbe22e191274cd8b62L116-R140), [link](https://github.com/voicepaw/so-vits-svc-fork/pull/715/files?diff=unified&w=0#diff-8036cfa6b74c166b17d0a5165f2077acbae837bc9b3ceafbe22e191274cd8b62L136-R159))
*  Pass pretrained model URLs from config file to `ensure_pretrained_model` function in `train` function ([link](https://github.com/voicepaw/so-vits-svc-fork/pull/715/files?diff=unified&w=0#diff-0d2c558b7595f48912f5c419f007c9ea09a8a5a741c97411772b2ced2a4b57d0L76-R86))
*  Add `DeviceStatsMonitor` callback to monitor GPU usage and memory during training ([link](https://github.com/voicepaw/so-vits-svc-fork/pull/715/files?diff=unified&w=0#diff-0d2c558b7595f48912f5c419f007c9ea09a8a5a741c97411772b2ced2a4b57d0R13), [link](https://github.com/voicepaw/so-vits-svc-fork/pull/715/files?diff=unified&w=0#diff-0d2c558b7595f48912f5c419f007c9ea09a8a5a741c97411772b2ced2a4b57d0L103-R114))
*  Import numpy module and create random state object for reproducible shuffling of paths in `preprocess_config` function ([link](https://github.com/voicepaw/so-vits-svc-fork/pull/715/files?diff=unified&w=0#diff-12570b18299b97c48d5230f83dde44985ab0eb548719de2548ca215b6c17d0ddL8-R9), [link](https://github.com/voicepaw/so-vits-svc-fork/pull/715/files?diff=unified&w=0#diff-12570b18299b97c48d5230f83dde44985ab0eb548719de2548ca215b6c17d0ddR35))
*  Replace `shuffle` function with `random.shuffle` function that uses random state object in `preprocess_config` function ([link](https://github.com/voicepaw/so-vits-svc-fork/pull/715/files?diff=unified&w=0#diff-12570b18299b97c48d5230f83dde44985ab0eb548719de2548ca215b6c17d0ddL44-R45))
*  Add check for empty input directory and raise ValueError in `preprocess_resample` function ([link](https://github.com/voicepaw/so-vits-svc-fork/pull/715/files?diff=unified&w=0#diff-8444b3e4031a033bb1612b74e9b5fa1ad360f75079ee23170a18fa3a149dd93eL106-R110))
*  Remove redundant line that appends input path to `in_paths` list in `preprocess_resample` function ([link](https://github.com/voicepaw/so-vits-svc-fork/pull/715/files?diff=unified&w=0#diff-8444b3e4031a033bb1612b74e9b5fa1ad360f75079ee23170a18fa3a149dd93eL128))



<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [ ] Code is up-to-date with the `main` branch
- [ ] This pull request follows [Contributing.md](https://github.com/34j/so-vits-svc-fork/blob/main/CONTRIBUTING.md)
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] `pre-commit run -a` passes with this change or ci passes
- [ ] `poetry run pytest` passes with this change or ci passes
- [ ] (There are new or updated unit tests validating the change)
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)

<!--
  🎉 Thank you for contributing!
-->
