### PR TITLE
fix(inference): remove weight norm on inference so `mps` backend will work without CPU fallback

### DIFF
--- a/src/so_vits_svc_fork/inference/core.py
+++ b/src/so_vits_svc_fork/inference/core.py
@@ -134,7 +134,11 @@ class Svc:
             **self.hps.model,
         )
         _ = utils.load_checkpoint(self.net_g_path, self.net_g, None)
-        _ = self.net_g.eval().to(self.device, dtype=self.dtype)
+        _ = self.net_g.eval()
+        for m in self.net_g.modules():
+            utils.remove_weight_norm_if_exists(m)
+        _ = self.net_g.to(self.device, dtype=self.dtype)
+        self.net_g = self.net_g
 
     def get_unit_f0(
         self,


### PR DESCRIPTION
### Description of change

Added code to remove weight norms from `hubert` and `net_g` (inference only for `net_g`), because at least as of now (PyTorch 2.0.1), the `mps` backend in pytorch does not support weight norm.

### Pull-Request Checklist

- [X] Code is up-to-date with the `main` branch
- [X] This pull request follows [Contributing.md](https://github.com/34j/so-vits-svc-fork/blob/main/CONTRIBUTING.md)
- [X] `pre-commit run -a` passes with this change or ci passes
- [X] `poetry run pytest` passes with this change or ci passes
- [ ] (There are new or updated unit tests validating the change) - it's a bit tricky to test. If the inference tests were active they would test this.
- [X] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)
