### PR TITLE
feat(cluster,preprocess_split): add batched loading to clustering & max length per clip to split

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3558,14 +3558,14 @@ files = [
 
 [[package]]
 name = "pytest"
-version = "7.3.2"
+version = "7.4.0"
 description = "pytest: simple powerful testing with Python"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pytest-7.3.2-py3-none-any.whl", hash = "sha256:cdcbd012c9312258922f8cd3f1b62a6580fdced17db6014896053d47cddf9295"},
-    {file = "pytest-7.3.2.tar.gz", hash = "sha256:ee990a3cc55ba808b80795a79944756f315c67c12b56abd3ac993a7b8c17030b"},
+    {file = "pytest-7.4.0-py3-none-any.whl", hash = "sha256:78bf16451a2eb8c7a2ea98e32dc119fd2aa758f1d5d66dbf0a59d69a3969df32"},
+    {file = "pytest-7.4.0.tar.gz", hash = "sha256:b4bf8c45bd59934ed84001ad51e11b4ee40d40a1229d2c79f9c592b0a3f6bd8a"},
 ]
 
 [package.dependencies]

--- a/src/so_vits_svc_fork/__main__.py
+++ b/src/so_vits_svc_fork/__main__.py
@@ -718,7 +718,13 @@ def pre_sd(
     default=-1,
     help="number of jobs (optimal value may depend on your RAM capacity and audio duration per file)",
 )
-@click.option("-l", "--max-length", type=float, default=10, help="max length of each split in seconds")
+@click.option(
+    "-l",
+    "--max-length",
+    type=float,
+    default=10,
+    help="max length of each split in seconds",
+)
 @click.option("-d", "--top-db", type=float, default=30, help="top db")
 @click.option("-f", "--frame-seconds", type=float, default=1, help="frame seconds")
 @click.option(
@@ -878,10 +884,19 @@ def onnx(
 @click.option(
     "-m/-nm", "--minibatch/--no-minibatch", default=True, help="use minibatch k-means"
 )
-@click.option("-b", "--batch-size", type=int, default=4096, help="batch size for minibatch kmeans")
-@click.option("-p/-np", "--partial-fit", default=False, help="use partial fit (only use with -m)")
+@click.option(
+    "-b", "--batch-size", type=int, default=4096, help="batch size for minibatch kmeans"
+)
+@click.option(
+    "-p/-np", "--partial-fit", default=False, help="use partial fit (only use with -m)"
+)
 def train_cluster(
-    input_dir: Path, output_path: Path, n_clusters: int, minibatch: bool, batch_size: int, partial_fit: bool
+    input_dir: Path,
+    output_path: Path,
+    n_clusters: int,
+    minibatch: bool,
+    batch_size: int,
+    partial_fit: bool,
 ) -> None:
     """Train k-means clustering"""
     from .cluster.train_cluster import main

--- a/src/so_vits_svc_fork/__main__.py
+++ b/src/so_vits_svc_fork/__main__.py
@@ -718,6 +718,7 @@ def pre_sd(
     default=-1,
     help="number of jobs (optimal value may depend on your RAM capacity and audio duration per file)",
 )
+@click.option("-l", "--max-length", type=float, default=10, help="max length of each split in seconds")
 @click.option("-d", "--top-db", type=float, default=30, help="top db")
 @click.option("-f", "--frame-seconds", type=float, default=1, help="frame seconds")
 @click.option(
@@ -727,6 +728,7 @@ def pre_sd(
 def pre_split(
     input_dir: Path | str,
     output_dir: Path | str,
+    max_length: float,
     top_db: int,
     frame_seconds: float,
     hop_seconds: float,
@@ -739,6 +741,7 @@ def pre_split(
     preprocess_split(
         input_dir=input_dir,
         output_dir=output_dir,
+        max_length=max_length,
         top_db=top_db,
         frame_seconds=frame_seconds,
         hop_seconds=hop_seconds,

--- a/src/so_vits_svc_fork/__main__.py
+++ b/src/so_vits_svc_fork/__main__.py
@@ -875,8 +875,10 @@ def onnx(
 @click.option(
     "-m/-nm", "--minibatch/--no-minibatch", default=True, help="use minibatch k-means"
 )
+@click.option("-b", "--batch-size", type=int, default=4096, help="batch size for minibatch kmeans")
+@click.option("-p/-np", "--partial-fit", default=False, help="use partial fit (only use with -m)")
 def train_cluster(
-    input_dir: Path, output_path: Path, n_clusters: int, minibatch: bool
+    input_dir: Path, output_path: Path, n_clusters: int, minibatch: bool, batch_size: int, partial_fit: bool
 ) -> None:
     """Train k-means clustering"""
     from .cluster.train_cluster import main
@@ -887,6 +889,8 @@ def train_cluster(
         n_clusters=n_clusters,
         verbose=True,
         use_minibatch=minibatch,
+        batch_size=batch_size,
+        partial_fit=partial_fit,
     )
 
 

--- a/src/so_vits_svc_fork/cluster/train_cluster.py
+++ b/src/so_vits_svc_fork/cluster/train_cluster.py
@@ -116,9 +116,8 @@ def main(
     input_dir = Path(input_dir)
     output_path = Path(output_path)
 
-    assert (
-        use_minibatch or not partial_fit
-    ), "partial_fit requires use_minibatch, exiting"
+    if not (use_minibatch or not partial_fit):
+        raise ValueError("partial_fit requires use_minibatch")
 
     def train_cluster_(input_path: Path, **kwargs: Any) -> tuple[str, dict]:
         return input_path.stem, train_cluster(input_path, **kwargs)

--- a/src/so_vits_svc_fork/cluster/train_cluster.py
+++ b/src/so_vits_svc_fork/cluster/train_cluster.py
@@ -4,6 +4,7 @@ from logging import getLogger
 from pathlib import Path
 from typing import Any
 
+import math
 import numpy as np
 import torch
 from cm_time import timer
@@ -18,58 +19,100 @@ def train_cluster(
     input_dir: Path | str,
     n_clusters: int,
     use_minibatch: bool = True,
+    batch_size: int = 4096,
+    partial_fit: bool = False,
     verbose: bool = False,
 ) -> dict:
     input_dir = Path(input_dir)
-    LOG.info(f"Loading features from {input_dir}")
-    features = []
-    for path in input_dir.rglob("*.data.pt"):
-        with path.open("rb") as f:
-            features.append(
-                torch.load(f, weights_only=True)["content"].squeeze(0).numpy().T
+    if not partial_fit:
+        LOG.info(f"Loading features from {input_dir}")
+        features = []
+        for path in input_dir.rglob("*.data.pt"):
+            with path.open("rb") as f:
+                features.append(
+                    torch.load(f, weights_only=True)["content"].squeeze(0).numpy().T
+                )
+        if not features:
+            raise ValueError(f"No features found in {input_dir}")
+        features = np.concatenate(features, axis=0).astype(np.float32)
+        if features.shape[0] < n_clusters:
+            raise ValueError(
+                "Too few HuBERT features to cluster. Consider using a smaller number of clusters."
             )
-    if not features:
-        raise ValueError(f"No features found in {input_dir}")
-    features = np.concatenate(features, axis=0).astype(np.float32)
-    if features.shape[0] < n_clusters:
-        raise ValueError(
-            "Too few HuBERT features to cluster. Consider using a smaller number of clusters."
+        LOG.info(
+            f"shape: {features.shape}, size: {features.nbytes/1024**2:.2f} MB, dtype: {features.dtype}"
         )
-    LOG.info(
-        f"shape: {features.shape}, size: {features.nbytes/1024**2:.2f} MB, dtype: {features.dtype}"
-    )
-    with timer() as t:
-        if use_minibatch:
+        with timer() as t:
+            if use_minibatch:
+                kmeans = MiniBatchKMeans(
+                    n_clusters=n_clusters,
+                    verbose=verbose,
+                    batch_size=batch_size,
+                    max_iter=80,
+                    n_init="auto",
+                ).fit(features)
+            else:
+                kmeans = KMeans(n_clusters=n_clusters, verbose=verbose, n_init="auto").fit(
+                    features
+                )
+        LOG.info(f"Clustering took {t.elapsed:.2f} seconds")
+
+        x = {
+            "n_features_in_": kmeans.n_features_in_,
+            "_n_threads": kmeans._n_threads,
+            "cluster_centers_": kmeans.cluster_centers_,
+        }
+        return x
+    else:
+        # minibatch partial fit
+        paths = list(input_dir.rglob("*.data.pt"))
+        if len(paths) == 0:
+            raise ValueError(f"No features found in {input_dir}")
+        LOG.info(f"Found {len(paths)} features in {input_dir}")
+        n_batches = math.ceil(len(paths)/batch_size)
+        LOG.info(f"Splitting into {n_batches} batches")
+        with timer() as t:
             kmeans = MiniBatchKMeans(
                 n_clusters=n_clusters,
                 verbose=verbose,
-                batch_size=4096,
+                batch_size=batch_size,
                 max_iter=80,
                 n_init="auto",
-            ).fit(features)
-        else:
-            kmeans = KMeans(n_clusters=n_clusters, verbose=verbose, n_init="auto").fit(
-                features
             )
-    LOG.info(f"Clustering took {t.elapsed:.2f} seconds")
+            for i in range(0, len(paths), batch_size):
+                LOG.info(f"Processing batch {i//batch_size+1}/{n_batches} for speaker {input_dir.stem}")
+                features = []
+                for path in paths[i : i + batch_size]:
+                    with path.open("rb") as f:
+                        features.append(
+                            torch.load(f, weights_only=True)[
+                                "content"
+                            ].squeeze(0).numpy().T
+                        )
+                features = np.concatenate(features, axis=0).astype(np.float32)
+                kmeans.partial_fit(features)
+        LOG.info(f"Clustering took {t.elapsed:.2f} seconds")
 
-    x = {
-        "n_features_in_": kmeans.n_features_in_,
-        "_n_threads": kmeans._n_threads,
-        "cluster_centers_": kmeans.cluster_centers_,
-    }
-    return x
-
+        x = {
+            "n_features_in_": kmeans.n_features_in_,
+            "_n_threads": kmeans._n_threads,
+            "cluster_centers_": kmeans.cluster_centers_,
+        }
+        return x
 
 def main(
     input_dir: Path | str,
     output_path: Path | str,
     n_clusters: int = 10000,
     use_minibatch: bool = True,
+    batch_size: int = 4096,
+    partial_fit: bool = False,
     verbose: bool = False,
 ) -> None:
     input_dir = Path(input_dir)
     output_path = Path(output_path)
+
+    assert use_minibatch or not partial_fit, "partial_fit requires use_minibatch, exiting"
 
     def train_cluster_(input_path: Path, **kwargs: Any) -> tuple[str, dict]:
         return input_path.stem, train_cluster(input_path, **kwargs)
@@ -80,6 +123,8 @@ def main(
                 speaker_name,
                 n_clusters=n_clusters,
                 use_minibatch=use_minibatch,
+                batch_size=batch_size,
+                partial_fit=partial_fit,
                 verbose=verbose,
             )
             for speaker_name in input_dir.iterdir()

--- a/src/so_vits_svc_fork/preprocessing/preprocess_split.py
+++ b/src/so_vits_svc_fork/preprocessing/preprocess_split.py
@@ -39,7 +39,10 @@ def _process_one(
             sub_end = min(sub_start + int(sr * max_length), end)
             audio_cut = audio[sub_start:sub_end]
             sf.write(
-                (output_dir / f"{input_path.stem}_{sub_start / sr:.3f}_{sub_end / sr:.3f}.wav"),
+                (
+                    output_dir
+                    / f"{input_path.stem}_{sub_start / sr:.3f}_{sub_end / sr:.3f}.wav"
+                ),
                 audio_cut,
                 sr,
             )

--- a/src/so_vits_svc_fork/preprocessing/preprocess_split.py
+++ b/src/so_vits_svc_fork/preprocessing/preprocess_split.py
@@ -17,6 +17,7 @@ def _process_one(
     output_dir: Path,
     sr: int,
     *,
+    max_length: float = 10.0,
     top_db: int = 30,
     frame_seconds: float = 0.5,
     hop_seconds: float = 0.1,
@@ -34,12 +35,14 @@ def _process_one(
     )
     output_dir.mkdir(parents=True, exist_ok=True)
     for start, end in tqdm(intervals, desc=f"Writing {input_path}"):
-        audio_cut = audio[start:end]
-        sf.write(
-            (output_dir / f"{input_path.stem}_{start / sr:.3f}_{end / sr:.3f}.wav"),
-            audio_cut,
-            sr,
-        )
+        for sub_start in range(start, end, int(sr * max_length)):
+            sub_end = min(sub_start + int(sr * max_length), end)
+            audio_cut = audio[sub_start:sub_end]
+            sf.write(
+                (output_dir / f"{input_path.stem}_{sub_start / sr:.3f}_{sub_end / sr:.3f}.wav"),
+                audio_cut,
+                sr,
+            )
 
 
 def preprocess_split(
@@ -47,6 +50,7 @@ def preprocess_split(
     output_dir: Path | str,
     sr: int,
     *,
+    max_length: float = 10.0,
     top_db: int = 30,
     frame_seconds: float = 0.5,
     hop_seconds: float = 0.1,
@@ -62,6 +66,7 @@ def preprocess_split(
                 input_path,
                 output_dir / input_path.relative_to(input_dir).parent,
                 sr,
+                max_length=max_length,
                 top_db=top_db,
                 frame_seconds=frame_seconds,
                 hop_seconds=hop_seconds,


### PR DESCRIPTION
### Description of change

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 53e4669</samp>

### Summary
🎛️🚚✂️

<!--
1.  🎛️ - This emoji represents the new command-line options that allow the user to adjust the settings of the splitting and clustering processes. It suggests the idea of tuning or tweaking the parameters to achieve the desired results.
2.  🚚 - This emoji represents the option to use partial fit for the k-means model, which enables the model to handle large feature sets by using batches. It suggests the idea of moving or transporting data in chunks, rather than all at once.
3.  ✂️ - This emoji represents the new parameter `max_length` that allows splitting audio files into smaller segments. It suggests the idea of cutting or trimming the audio files to fit the specified duration.
-->
This pull request enhances the preprocessing pipeline of the `so-vits-svc-fork` project by adding new command-line options and parameters to the `pre_split` and `train_cluster` modules. These options allow the user to split audio files by duration, train k-means on batches of features, and adjust the splitting and clustering criteria. These changes improve the efficiency and flexibility of the pipeline for large-scale speaker verification tasks.

> _To process audio files with ease_
> _We added some new options, please_
> _Use `max_length` to split_
> _And `partial_fit` to fit_
> _The k-means and HuBERT features_

### Walkthrough
*  Add command-line options and parameters for splitting and clustering audio files ([link](https://github.com/voicepaw/so-vits-svc-fork/pull/786/files?diff=unified&w=0#diff-1e96e26cdf5a3809068061c9616dc62d3158dc61dc3e8321ce9310d019430285R721-R727), [link](https://github.com/voicepaw/so-vits-svc-fork/pull/786/files?diff=unified&w=0#diff-1e96e26cdf5a3809068061c9616dc62d3158dc61dc3e8321ce9310d019430285R737), [link](https://github.com/voicepaw/so-vits-svc-fork/pull/786/files?diff=unified&w=0#diff-1e96e26cdf5a3809068061c9616dc62d3158dc61dc3e8321ce9310d019430285R750), [link](https://github.com/voicepaw/so-vits-svc-fork/pull/786/files?diff=unified&w=0#diff-1e96e26cdf5a3809068061c9616dc62d3158dc61dc3e8321ce9310d019430285L878-R899), [link](https://github.com/voicepaw/so-vits-svc-fork/pull/786/files?diff=unified&w=0#diff-1e96e26cdf5a3809068061c9616dc62d3158dc61dc3e8321ce9310d019430285R910-R911), [link](https://github.com/voicepaw/so-vits-svc-fork/pull/786/files?diff=unified&w=0#diff-5ec4730041d5ef4e26759f2624cb6779c6bc7ca950eeefb162fbd0cd8391aed6L21-R104), [link](https://github.com/voicepaw/so-vits-svc-fork/pull/786/files?diff=unified&w=0#diff-5ec4730041d5ef4e26759f2624cb6779c6bc7ca950eeefb162fbd0cd8391aed6R112-R113), [link](https://github.com/voicepaw/so-vits-svc-fork/pull/786/files?diff=unified&w=0#diff-5ec4730041d5ef4e26759f2624cb6779c6bc7ca950eeefb162fbd0cd8391aed6R119-R122), [link](https://github.com/voicepaw/so-vits-svc-fork/pull/786/files?diff=unified&w=0#diff-951dd1cfcdcfd2bcf09cd352ca0ac518e1e836eb68908af727391d11b81ab1e0R20), [link](https://github.com/voicepaw/so-vits-svc-fork/pull/786/files?diff=unified&w=0#diff-951dd1cfcdcfd2bcf09cd352ca0ac518e1e836eb68908af727391d11b81ab1e0R56), [link](https://github.com/voicepaw/so-vits-svc-fork/pull/786/files?diff=unified&w=0#diff-951dd1cfcdcfd2bcf09cd352ca0ac518e1e836eb68908af727391d11b81ab1e0R72))
* Import the `math` module in `train_cluster.py` for calculating the number of batches for the partial fit method ([link](https://github.com/voicepaw/so-vits-svc-fork/pull/786/files?diff=unified&w=0#diff-5ec4730041d5ef4e26759f2624cb6779c6bc7ca950eeefb162fbd0cd8391aed6R3))
* Add an assertion error in `train_cluster.py` to check that the partial fit option is only used with the minibatch option ([link](https://github.com/voicepaw/so-vits-svc-fork/pull/786/files?diff=unified&w=0#diff-5ec4730041d5ef4e26759f2624cb6779c6bc7ca950eeefb162fbd0cd8391aed6R112-R113))



#### [1] Added Batched Loading Option to Train Cluster
- Added two parameters specific to MiniBatchKMeans to the train_cluster script: `batch_size` and `partial_fit`.
- `batch_size` controls the corresponding parameter of the algorithm.
- `partial_fit` calls partial_fit instead of fit and batches feature loading to avoid OOM for large datasets.
- The corresponding options are enabled in the cli via __main__.py

#### [2] Added Max Length Option to Preprocess Split
- Added one parameter `max_length: float = 10.0` to the preprocess_split script.
- `max_length` is the maximum length of each split in seconds. This allows users to easily satisfy the training criteria of having audio files <= 10.0s each.

### Pull-Request Checklist

- [x] Code is up-to-date with the `main` branch
- [x] This pull request follows [Contributing.md](https://github.com/34j/so-vits-svc-fork/blob/main/CONTRIBUTING.md)
- [ ] This pull request links relevant issues as `Fixes #0000` **NA**
- [x] `pre-commit run -a` passes with this change or ci passes
- [x] `poetry run pytest` passes with this change or ci passes
- [ ] (There are new or updated unit tests validating the change) **NA**
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)

<!--
  🎉 Thank you for contributing!
-->
