### PR TITLE
fix(pre-sd): make Pyanote.audio use GPU

### DIFF
--- a/src/so_vits_svc_fork/preprocessing/preprocess_speaker_diarization.py
+++ b/src/so_vits_svc_fork/preprocessing/preprocess_speaker_diarization.py
@@ -34,7 +34,7 @@ def _process_one(
     )
     if pipeline is None:
         raise ValueError("Failed to load pipeline")
-
+    pipeline = pipeline.to(torch.device("cuda"))
     LOG.info(f"Processing {input_path}. This may take a while...")
     diarization = pipeline(
         input_path, min_speakers=min_speakers, max_speakers=max_speakers


### PR DESCRIPTION
<!--
  😀 Wonderful! Thank you for opening a pull request.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

<!--
  First, have Copilot write it down.
-->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at d746c14</samp>

### Summary
🚀🖥️🎙️

<!--
1.  🚀 This emoji can be used to indicate that the change is related to speeding up or enhancing the performance of the pipeline object by using GPU acceleration. It can also suggest that the change is a significant improvement or a breakthrough for the preprocessing module.
2.  🖥️ This emoji can be used to indicate that the change is related to the cuda device or the computer hardware that enables the GPU acceleration. It can also suggest that the change is a technical or low-level modification that affects the underlying implementation of the pipeline object.
3.  🎙️ This emoji can be used to indicate that the change is related to the speaker diarization task or the audio processing aspect of the preprocessing module. It can also suggest that the change is a functional or high-level modification that affects the output or the result of the pipeline object.
-->
Move pipeline object to GPU device for faster speaker diarization. This is part of a pull request to optimize the preprocessing module in `src/so_vits_svc_fork/preprocessing`.

> _`pipeline` on cuda_
> _speeds up speaker diarization_
> _a winter solstice_

### Walkthrough
* Move the pipeline object to the cuda device for GPU acceleration ([link](https://github.com/voicepaw/so-vits-svc-fork/pull/1009/files?diff=unified&w=0#diff-4d0be79770611468116c824a3dd2b535a729fd764a1a2f0548bd1c534aeb157cL37-R37))


### Description

fix: the pyanote.audio implementation used for the 'svc pre-sd' command doesn't use the CUDA GPU by default, even though it says that it does.

Fixes #1007

<!--
  Please be clear and concise about the change's purpose,
  why it's necessary, and how you've verified its correctness.

  It may be helpful to include the current and new behavior.

  If this change relates to an open issue, you can link it here.
  If you include `Fixes #0000` (replace `0000` with the issue number),
  the issue will automatically be marked as fixed and closed upon merge.
-->

### Pull-Request Checklist

<!--
  Please ensure that you review and check all of the following.

  If an item isn't applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `main` branch
- [x] This pull request adheres to [Contributing.md](https://github.com/34j/so-vits-svc-fork/blob/main/CONTRIBUTING.md)
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] `pre-commit run -a` passes with this change or CI passes
- [x] `poetry run pytest` passes with this change or CI passes
- [x] (There are new or updated unit tests validating the change)
- [ ] Documentation has been updated to reflect this change N/A
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)

<!--
  🎉 Thank you for contributing!
-->