### PR TITLE
fix(pre-sd): set speaker-diarization version to 3.1 for pyannote.audio 3.1.1 compatibility

### DIFF
--- a/src/so_vits_svc_fork/preprocessing/preprocess_speaker_diarization.py
+++ b/src/so_vits_svc_fork/preprocessing/preprocess_speaker_diarization.py
@@ -30,7 +30,7 @@ def _process_one(
         LOG.warning(f"Failed to read {input_path}: {e}")
         return
     pipeline = Pipeline.from_pretrained(
-        "pyannote/speaker-diarization", use_auth_token=huggingface_token
+        "pyannote/speaker-diarization-3.1", use_auth_token=huggingface_token
     )
     if pipeline is None:
         raise ValueError("Failed to load pipeline")


### PR DESCRIPTION
Fix #1156 

### Description of change

 Set speaker-diarization version to 3.1 for pyannote.audio 3.1.1 compatibility. Ensure compatibility with torch 2.2.2+cu121 as well.