### PR TITLE
docs(readme): update CIVITAI Model URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ svc vc
 svc infer source.wav
 ```
 
-Pretrained models are available on [Hugging Face](https://huggingface.co/models?search=so-vits-svc) or [CIVITAI](https://civitai.com/?query=so-vits-svc).
+Pretrained models are available on [Hugging Face](https://huggingface.co/models?search=so-vits-svc) or [CIVITAI](https://civitai.com/tag/so-vits-svc-fork).
 
 #### Notes
 

--- a/src/so_vits_svc_fork/gui.py
+++ b/src/so_vits_svc_fork/gui.py
@@ -362,9 +362,11 @@ def main():
                 sg.FileBrowse(
                     initial_folder=".",
                     key="input_path_browse",
-                    file_types=get_supported_file_types_concat()
-                    if os.name == "nt"
-                    else get_supported_file_types(),
+                    file_types=(
+                        get_supported_file_types_concat()
+                        if os.name == "nt"
+                        else get_supported_file_types()
+                    ),
                 ),
                 sg.FolderBrowse(
                     button_text="Browse(Folder)",


### PR DESCRIPTION
Hi, this is simple README.md edit just to update CIVITAI Link.

The old link no longer works for quite sometime, and this small README.md update use correct CIVITAI Link.

CIVITAI has tag for `so-vits-svc-fork` which is contain 15 model compared with just `so-vits-svc` (10 model)

Thank You