### PR TITLE
Update utils.py and notebook update for colab

### DIFF
--- a/notebooks/so-vits-svc-fork-4.0.ipynb
+++ b/notebooks/so-vits-svc-fork-4.0.ipynb
@@ -45,17 +45,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#@title Install dependencies\n",
-    "#@markdown pip may fail to resolve dependencies and raise ERROR, but it can be ignored.\n",
-    "!python -m pip install -U pip wheel\n",
-    "%pip install -U ipython \n",
-    "\n",
-    "#@markdown Branch (for development)\n",
-    "BRANCH = \"none\" #@param {\"type\": \"string\"}\n",
-    "if BRANCH == \"none\":\n",
-    "    %pip install -U so-vits-svc-fork\n",
-    "else:\n",
-    "    %pip install -U git+https://github.com/34j/so-vits-svc-fork.git@{BRANCH}"
+    "!pip install -U so-vits-svc-fork"
    ]
   },
   {

--- a/src/so_vits_svc_fork/utils.py
+++ b/src/so_vits_svc_fork/utils.py
@@ -389,7 +389,6 @@ def latest_checkpoint_path(dir_path: Path | str, regex: str = "G_*.pth") -> Path
         return None
     return paths[-1]
 
-
 def plot_spectrogram_to_numpy(spectrogram: ndarray) -> ndarray:
     matplotlib.use("Agg")
     fig, ax = plt.subplots(figsize=(10, 2))
@@ -400,8 +399,10 @@ def plot_spectrogram_to_numpy(spectrogram: ndarray) -> ndarray:
     plt.tight_layout()
 
     fig.canvas.draw()
-    data = np.fromstring(fig.canvas.tostring_rgb(), dtype=np.uint8, sep="")
-    data = data.reshape(fig.canvas.get_width_height()[::-1] + (3,))
+    # Use np.frombuffer instead of np.fromstring
+    buf = fig.canvas.tostring_argb()
+    data = np.frombuffer(buf, dtype=np.uint8)
+    data = data.reshape(fig.canvas.get_width_height()[::-1] + (4,)) # ARGB has 4 channels
     plt.close()
     return data
 
@@ -451,8 +452,10 @@ def plot_data_to_numpy(x: ndarray, y: ndarray) -> ndarray:
     plt.tight_layout()
 
     fig.canvas.draw()
-    data = np.fromstring(fig.canvas.tostring_rgb(), dtype=np.uint8, sep="")
-    data = data.reshape(fig.canvas.get_width_height()[::-1] + (3,))
+    # Use np.frombuffer instead of np.fromstring
+    buf = fig.canvas.tostring_argb()
+    data = np.frombuffer(buf, dtype=np.uint8)
+    data = data.reshape(fig.canvas.get_width_height()[::-1] + (4,)) # ARGB has 4 channels
     plt.close()
     return data
 

--- a/src/so_vits_svc_fork/utils.py
+++ b/src/so_vits_svc_fork/utils.py
@@ -389,6 +389,7 @@ def latest_checkpoint_path(dir_path: Path | str, regex: str = "G_*.pth") -> Path
         return None
     return paths[-1]
 
+
 def plot_spectrogram_to_numpy(spectrogram: ndarray) -> ndarray:
     matplotlib.use("Agg")
     fig, ax = plt.subplots(figsize=(10, 2))
@@ -402,7 +403,9 @@ def plot_spectrogram_to_numpy(spectrogram: ndarray) -> ndarray:
     # Use np.frombuffer instead of np.fromstring
     buf = fig.canvas.tostring_argb()
     data = np.frombuffer(buf, dtype=np.uint8)
-    data = data.reshape(fig.canvas.get_width_height()[::-1] + (4,)) # ARGB has 4 channels
+    data = data.reshape(
+        fig.canvas.get_width_height()[::-1] + (4,)
+    )  # ARGB has 4 channels
     plt.close()
     return data
 
@@ -455,7 +458,9 @@ def plot_data_to_numpy(x: ndarray, y: ndarray) -> ndarray:
     # Use np.frombuffer instead of np.fromstring
     buf = fig.canvas.tostring_argb()
     data = np.frombuffer(buf, dtype=np.uint8)
-    data = data.reshape(fig.canvas.get_width_height()[::-1] + (4,)) # ARGB has 4 channels
+    data = data.reshape(
+        fig.canvas.get_width_height()[::-1] + (4,)
+    )  # ARGB has 4 channels
     plt.close()
     return data
 


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

Description of change


1. Fixing installation for the sovits fork to prevent the runtime restart failiure for issue Fixes 1251
2. Fixing Utils.py to use np.frombuffer() instead of np.fromstring() to interpret the raw byte data from the canvas. np.frombuffer() creates a NumPy array that shares the same memory as the buffer object (the byte string in this case), without making a copy. Fixes 852



copilot:all

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `main` branch
- [ ] This pull request follows [Contributing.md](https://github.com/34j/so-vits-svc-fork/blob/main/CONTRIBUTING.md)
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] `pre-commit run -a` passes with this change or ci passes
- [ ] `poetry run pytest` passes with this change or ci passes
- [ ] (There are new or updated unit tests validating the change)
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)

<!--
  🎉 Thank you for contributing!
-->
